### PR TITLE
refactor: Simplify new stream crawling

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -5,6 +5,7 @@
     },
     "crawler": {
         "subscribeDuration": 10000,
+        "subscribeJoinTimeout": 60000,
         "newStreamAnalysisDelay": 60000,
         "iterationDelay": 3600000
     },

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -11,6 +11,7 @@ export interface Config {
     }
     crawler: {
         subscribeDuration: number
+        subscribeJoinTimeout: number
         newStreamAnalysisDelay: number
         iterationDelay: number
     }

--- a/src/StreamrClientFacade.ts
+++ b/src/StreamrClientFacade.ts
@@ -29,11 +29,13 @@ export const peerDescriptorTranslator = (json: NetworkPeerDescriptor): PeerDescr
 export class StreamrClientFacade {
 
     private readonly client: StreamrClient
+    private readonly config: Config
 
     constructor(
         @Inject(CONFIG_TOKEN) config: Config
     ) {
         this.client = new StreamrClient(config.client)
+        this.config = config
     }
 
     getAllStreams(): AsyncIterable<Stream> {
@@ -84,7 +86,7 @@ export class StreamrClientFacade {
 
     async getNetworkNodeFacade(): Promise<NetworkNodeFacade> {
         const node = (await this.client.getNode()) as NetworkNode
-        return new NetworkNodeFacade(node)
+        return new NetworkNodeFacade(node, this.config)
     }
 
     getEntryPoints(): PeerDescriptor[] {

--- a/src/crawler/NetworkNodeFacade.ts
+++ b/src/crawler/NetworkNodeFacade.ts
@@ -2,8 +2,7 @@ import { PeerDescriptor } from '@streamr/dht'
 import { NetworkNode, NodeInfo, streamPartIdToDataKey } from '@streamr/trackerless-network'
 import EventEmitter3 from 'eventemitter3'
 import { StreamMessage, StreamPartID } from 'streamr-client'
-
-const JOIN_TIMEOUT = 60 * 1000  // TODO from config
+import { Config } from '../Config'
 
 export interface Events {
     subscribe: () => void
@@ -13,16 +12,20 @@ export interface Events {
 export class NetworkNodeFacade {
 
     private readonly node: NetworkNode
+    private readonly config: Config
     private readonly eventEmitter: EventEmitter3<Events> = new EventEmitter3()
 
     constructor(
-        node: NetworkNode
+        node: NetworkNode,
+        config: Config
     ) {
         this.node = node
+        this.config = config
     }
 
     async subscribe(streamPartId: StreamPartID): Promise<void> {
-        await this.node.join(streamPartId, { minCount: 1, timeout: JOIN_TIMEOUT })
+        const timeout = this.config.crawler.subscribeJoinTimeout
+        await this.node.join(streamPartId, { minCount: 1, timeout })
         this.eventEmitter.emit('subscribe')
     }
 

--- a/src/crawler/Topology.ts
+++ b/src/crawler/Topology.ts
@@ -23,12 +23,4 @@ export class Topology {
         }
         return nodeIds
     }
-
-    getNodeInfos(): NodeInfo[] {
-        return this.nodeInfos
-    }
-
-    addNodeInfos(nodeInfos: NodeInfo[]): void {
-        this.nodeInfos.push(...nodeInfos)
-    }
 }


### PR DESCRIPTION
Simplify crawling done after a new stream is created. Previously it did multiple crawls (one for each partition), and merged the results. Now it does just one crawl. This implementation is simpler and it ensures that each `NodeInfo` is in the `Topology` only once in a typical case where same node has been joined to multiple partitions of a stream.

Also added new config option `crawler.subscribeJoinTimeout` and enhanced end-to-end tests to use multi-partition streams.