### PR TITLE
Store topology nodes to DB

### DIFF
--- a/initialize-database.sql
+++ b/initialize-database.sql
@@ -13,3 +13,7 @@ CREATE TABLE IF NOT EXISTS streams (
     INDEX streams_subscriberCount (subscriberCount)
 );
 
+CREATE TABLE IF NOT EXISTS nodes (
+    id CHAR(40) NOT NULL PRIMARY KEY,
+    ipAddress VARCHAR(15)
+);

--- a/src/StreamrClientFacade.ts
+++ b/src/StreamrClientFacade.ts
@@ -93,6 +93,10 @@ export class StreamrClientFacade {
         return this.client.getConfig().network.controlLayer.entryPoints!.map(peerDescriptorTranslator)
     }
 
+    async getNodeId(): Promise<DhtAddress> {
+        return await this.client.getNodeId()
+    }
+
     async destroy(): Promise<void> {
         await this.client.destroy()
     }

--- a/src/api/APIServer.ts
+++ b/src/api/APIServer.ts
@@ -10,6 +10,7 @@ import { Container, Inject, Service } from 'typedi'
 import { Config, CONFIG_TOKEN } from '../Config'
 import { StreamResolver } from './StreamResolver'
 import { SummaryResolver } from './SummaryResolver'
+import { NodeResolver } from './NodeResolver'
 
 const logger = new Logger(module)
 
@@ -29,7 +30,7 @@ export class APIServer {
 
     async start(): Promise<void> {
         const schema = await buildSchema({
-            resolvers: [StreamResolver, SummaryResolver],
+            resolvers: [StreamResolver, NodeResolver, SummaryResolver],
             container: Container,
             validate: false
         })

--- a/src/api/NodeResolver.ts
+++ b/src/api/NodeResolver.ts
@@ -1,0 +1,26 @@
+import { Arg, Int, Query, Resolver } from 'type-graphql'
+import { Inject, Service } from 'typedi'
+import { Nodes } from '../entities/Node'
+import { NodeRepository } from '../repository/NodeRepository'
+
+@Resolver()
+@Service()
+export class NodeResolver {
+
+    private repository: NodeRepository
+
+    constructor(
+        @Inject() repository: NodeRepository
+    ) {
+        this.repository = repository
+    }
+
+    @Query(() => Nodes)
+    async nodes(
+        @Arg("ids", () => [String], { nullable: true }) ids?: string[],
+        @Arg("pageSize", () => Int, { nullable: true }) pageSize?: number,
+        @Arg("cursor", { nullable: true }) cursor?: string,
+    ): Promise<Nodes> {
+        return this.repository.getNodes(ids, pageSize, cursor)
+    }
+}

--- a/src/crawler/Topology.ts
+++ b/src/crawler/Topology.ts
@@ -3,10 +3,12 @@ import { StreamPartIDUtils } from '@streamr/protocol'
 import { NodeInfo } from '@streamr/trackerless-network'
 import { Multimap } from '@streamr/utils'
 import { DhtAddress, StreamPartID } from 'streamr-client'
+import { numberToIpv4 } from '../utils'
 
-interface Node {
+export interface Node {
     id: DhtAddress
     streamPartNeighbors: Multimap<StreamPartID, DhtAddress>
+    ipAddress?: string
 }
 
 export class Topology {
@@ -26,7 +28,8 @@ export class Topology {
             const nodeId = getNodeIdFromPeerDescriptor(info.peerDescriptor)
             this.nodes.set(nodeId, {
                 id: nodeId,
-                streamPartNeighbors
+                streamPartNeighbors,
+                ipAddress: (info.peerDescriptor.ipAddress !== undefined) ? numberToIpv4(info.peerDescriptor.ipAddress) : undefined
             })
         }
     }

--- a/src/entities/Node.ts
+++ b/src/entities/Node.ts
@@ -1,0 +1,19 @@
+import { Field, ObjectType } from 'type-graphql'
+
+/* eslint-disable indent */
+@ObjectType()
+export class Node {
+    @Field()
+    id!: string
+    @Field(() => String, { nullable: true })
+    ipAddress!: string | null
+}
+
+/* eslint-disable indent */
+@ObjectType()
+export class Nodes {
+    @Field(() => [Node])
+    items!: Node[]
+    @Field(() => String, { nullable: true })
+    cursor!: string | null
+}

--- a/src/entities/Summary.ts
+++ b/src/entities/Summary.ts
@@ -7,4 +7,6 @@ export class Summary {
     streamCount!: number
     @Field(() => Float)
     messagesPerSecond!: number
+    @Field(() => Int)
+    nodeCount!: number
 }

--- a/src/repository/ConnectionPool.ts
+++ b/src/repository/ConnectionPool.ts
@@ -1,6 +1,8 @@
-import { Pool, RowDataPacket, createPool } from 'mysql2/promise'
+import { Pool, RowDataPacket, createPool, PoolConnection } from 'mysql2/promise'
 import { Inject, Service } from 'typedi'
 import { CONFIG_TOKEN, Config } from '../Config'
+
+const DEFAULT_PAGE_SIZE = 100
 
 @Service()
 export class ConnectionPool {
@@ -19,7 +21,7 @@ export class ConnectionPool {
     }
 
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-    async queryOrExecute<T extends RowDataPacket[]>(sql: string, params?: any): Promise<T> {
+    async queryOrExecute<T extends RowDataPacket[]>(sql: string, params?: any[]): Promise<T> {
         const connection = await this.delegatee.getConnection()
         try {
             const [ rows ] = await connection.query<T>(
@@ -30,6 +32,28 @@ export class ConnectionPool {
         } finally {
             connection.release()
         }
+    }
+
+    async queryPaginated<T extends RowDataPacket[]>(
+        sql: string, params: any[], pageSize?: number, cursor?: string
+    ): Promise<{ items: T, cursor: string | null }> {
+        const limit = pageSize ?? DEFAULT_PAGE_SIZE
+        // The cursor is currently just an offset to the result set. We can later implement
+        // enhanced cursor functionality if needed (e.g. cursor can be the last item of
+        // the result set or a token which references to a stateful cache).
+        const offset = (cursor !== undefined) ? parseInt(cursor, 10) : 0
+        const rows = await this.queryOrExecute<T>(
+            `${sql} LIMIT ? OFFSET ?`,
+            [...params, limit, offset]
+        )
+        return {
+            items: rows,
+            cursor: (rows.length === pageSize) ? String(offset + rows.length) : null
+        }
+    }
+
+    async getConnection(): Promise<PoolConnection> {
+        return this.delegatee.getConnection()
     }
 
     async destroy(): Promise<void> {

--- a/src/repository/NodeRepository.ts
+++ b/src/repository/NodeRepository.ts
@@ -1,0 +1,63 @@
+import { Logger } from '@streamr/utils'
+import { RowDataPacket } from 'mysql2'
+import { Inject, Service } from 'typedi'
+import { Topology } from '../crawler/Topology'
+import { Nodes } from '../entities/Node'
+import { createSqlQuery } from '../utils'
+import { ConnectionPool } from './ConnectionPool'
+
+interface NodeRow extends RowDataPacket {
+    id: string
+    ipAddress: string | null
+}
+
+const logger = new Logger(module)
+
+@Service()
+export class NodeRepository {
+
+    private readonly connectionPool: ConnectionPool
+
+    constructor(
+        @Inject() connectionPool: ConnectionPool
+    ) {
+        this.connectionPool = connectionPool
+    }
+
+    async getNodes(
+        ids?: string[],
+        pageSize?: number,
+        cursor?: string
+    ): Promise<Nodes> {
+        logger.info('Query: getNodes', { ids, pageSize, cursor })
+        const whereClauses = []
+        const params = []
+        if (ids !== undefined) {
+            whereClauses.push('id in (?)')
+            params.push(ids)
+        }
+        const sql = createSqlQuery(
+            `SELECT id, ipAddress FROM nodes`,
+            whereClauses
+        )
+        return this.connectionPool.queryPaginated<NodeRow[]>(sql, params)
+    }
+
+    async replaceNetworkTopology(topology: Topology): Promise<void> {
+        const nodes = topology.getNodes().map((node) => {
+            return [node.id, node.ipAddress]
+        })
+        const connection = await this.connectionPool.getConnection()
+        try {
+            await connection.beginTransaction()
+            await connection.query('DELETE FROM nodes')
+            await connection.query('INSERT INTO nodes (id, ipAddress) VALUES ?', [nodes])
+            await connection.commit()
+        } catch (e) {
+            connection.rollback()
+            throw e
+        } finally {
+            connection.release()
+        }
+    }
+}


### PR DESCRIPTION
Store all nodes of a topology to the database. 

New queries
- simple GraphQL interface to query all nodes, or a subset of nodes filtered by ids. 
- new `nodeCount` field to the `summary` endpoint.

## Refactoring

`ConnectionPool#queryPaginated` helper method and `createSqlQuery` utility method.

## Future improvements

Should we store new nodes and neighbors which we find when we crawl a single newly created stream.