### PR TITLE
refactor: Do not use GraphQL types in repositories

### DIFF
--- a/src/repository/ConnectionPool.ts
+++ b/src/repository/ConnectionPool.ts
@@ -1,10 +1,10 @@
-import { Pool, RowDataPacket, createPool, PoolConnection } from 'mysql2/promise'
+import { Pool, createPool, PoolConnection } from 'mysql2/promise'
 import { Inject, Service } from 'typedi'
 import { CONFIG_TOKEN, Config } from '../Config'
 
 const DEFAULT_PAGE_SIZE = 100
 
-export interface PaginatedListFragment<T extends RowDataPacket> {
+export interface PaginatedListFragment<T> {
     items: T[]
     cursor: string | null
 }
@@ -26,20 +26,20 @@ export class ConnectionPool {
     }
 
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-    async queryOrExecute<T extends RowDataPacket>(sql: string, params?: any[]): Promise<T[]> {
+    async queryOrExecute<T>(sql: string, params?: any[]): Promise<T[]> {
         const connection = await this.delegatee.getConnection()
         try {
-            const [ rows ] = await connection.query<T[]>(
+            const [ rows ] = await connection.query(
                 sql,
                 params
             )
-            return rows
+            return rows as T[]
         } finally {
             connection.release()
         }
     }
 
-    async queryPaginated<T extends RowDataPacket>(
+    async queryPaginated<T>(
         sql: string, params: any[], pageSize?: number, cursor?: string
     ): Promise<PaginatedListFragment<T>> {
         const limit = pageSize ?? DEFAULT_PAGE_SIZE

--- a/src/repository/ConnectionPool.ts
+++ b/src/repository/ConnectionPool.ts
@@ -4,8 +4,8 @@ import { CONFIG_TOKEN, Config } from '../Config'
 
 const DEFAULT_PAGE_SIZE = 100
 
-export interface PaginatedListFragment<T extends RowDataPacket[]> {
-    items: T
+export interface PaginatedListFragment<T extends RowDataPacket> {
+    items: T[]
     cursor: string | null
 }
 
@@ -26,10 +26,10 @@ export class ConnectionPool {
     }
 
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-    async queryOrExecute<T extends RowDataPacket[]>(sql: string, params?: any[]): Promise<T> {
+    async queryOrExecute<T extends RowDataPacket>(sql: string, params?: any[]): Promise<T[]> {
         const connection = await this.delegatee.getConnection()
         try {
-            const [ rows ] = await connection.query<T>(
+            const [ rows ] = await connection.query<T[]>(
                 sql,
                 params
             )
@@ -39,7 +39,7 @@ export class ConnectionPool {
         }
     }
 
-    async queryPaginated<T extends RowDataPacket[]>(
+    async queryPaginated<T extends RowDataPacket>(
         sql: string, params: any[], pageSize?: number, cursor?: string
     ): Promise<PaginatedListFragment<T>> {
         const limit = pageSize ?? DEFAULT_PAGE_SIZE

--- a/src/repository/NodeRepository.ts
+++ b/src/repository/NodeRepository.ts
@@ -1,11 +1,10 @@
 import { Logger } from '@streamr/utils'
-import { RowDataPacket } from 'mysql2'
 import { Inject, Service } from 'typedi'
 import { Topology } from '../crawler/Topology'
 import { createSqlQuery } from '../utils'
 import { ConnectionPool, PaginatedListFragment } from './ConnectionPool'
 
-export interface NodeRow extends RowDataPacket {
+export interface NodeRow {
     id: string
     ipAddress: string | null
 }

--- a/src/repository/NodeRepository.ts
+++ b/src/repository/NodeRepository.ts
@@ -27,7 +27,7 @@ export class NodeRepository {
         ids?: string[],
         pageSize?: number,
         cursor?: string
-    ): Promise<PaginatedListFragment<NodeRow[]>> {
+    ): Promise<PaginatedListFragment<NodeRow>> {
         logger.info('Query: getNodes', { ids, pageSize, cursor })
         const whereClauses = []
         const params = []
@@ -39,7 +39,7 @@ export class NodeRepository {
             `SELECT id, ipAddress FROM nodes`,
             whereClauses
         )
-        return this.connectionPool.queryPaginated<NodeRow[]>(sql, params)
+        return this.connectionPool.queryPaginated<NodeRow>(sql, params)
     }
 
     async replaceNetworkTopology(topology: Topology): Promise<void> {

--- a/src/repository/StreamRepository.ts
+++ b/src/repository/StreamRepository.ts
@@ -1,19 +1,19 @@
 import { Logger } from '@streamr/utils'
-import { RowDataPacket } from 'mysql2/promise'
 import { Inject, Service } from 'typedi'
 import { StreamrClientFacade } from '../StreamrClientFacade'
 import { OrderDirection } from '../entities/OrderDirection'
-import { Stream, StreamOrderBy } from '../entities/Stream'
+import { StreamOrderBy } from '../entities/Stream'
 import { collect, createSqlQuery } from '../utils'
 import { ConnectionPool, PaginatedListFragment } from './ConnectionPool'
 
-export interface StreamRow extends RowDataPacket {
+export interface StreamRow {
     id: string
     description: string | null
     peerCount: number
     messagesPerSecond: number
     publisherCount: number | null
     subscriberCount: number | null
+    crawlTimestamp: string
 }
 
 const EMPTY_SEARCH_RESULT = {
@@ -128,7 +128,7 @@ export class StreamRepository {
         )
     }
 
-    async replaceStream(stream: Stream): Promise<void> {
+    async replaceStream(stream: Omit<StreamRow, 'crawlTimestamp'>): Promise<void> {
         await this.connectionPool.queryOrExecute(
             `REPLACE INTO streams (
                 id, description, peerCount, messagesPerSecond, publisherCount, subscriberCount, crawlTimestamp

--- a/src/repository/StreamRepository.ts
+++ b/src/repository/StreamRepository.ts
@@ -71,7 +71,7 @@ export class StreamRepository {
             whereClauses,
             StreamRepository.formOrderByExpression(orderBy ?? StreamOrderBy.ID, orderDirection ?? OrderDirection.ASC)
         )
-        return this.connectionPool.queryPaginated<StreamRow[]>(sql, params, pageSize, cursor)
+        return this.connectionPool.queryPaginated<StreamRow>(sql, params, pageSize, cursor)
     }
 
     private static formOrderByExpression(orderBy: StreamOrderBy, orderDirection: OrderDirection) {
@@ -110,7 +110,7 @@ export class StreamRepository {
     }
 
     async getAllStreams(): Promise<{ id: string, crawlTimestamp: number }[]> {
-        const rows = await this.connectionPool.queryOrExecute<StreamRow[]>(
+        const rows = await this.connectionPool.queryOrExecute<StreamRow>(
             'SELECT id, crawlTimestamp FROM streams'
         )
         return rows.map((r: StreamRow) => {

--- a/src/repository/StreamRepository.ts
+++ b/src/repository/StreamRepository.ts
@@ -3,11 +3,11 @@ import { RowDataPacket } from 'mysql2/promise'
 import { Inject, Service } from 'typedi'
 import { StreamrClientFacade } from '../StreamrClientFacade'
 import { OrderDirection } from '../entities/OrderDirection'
-import { StreamOrderBy, Stream, Streams } from '../entities/Stream'
+import { Stream, StreamOrderBy } from '../entities/Stream'
 import { collect, createSqlQuery } from '../utils'
-import { ConnectionPool } from './ConnectionPool'
+import { ConnectionPool, PaginatedListFragment } from './ConnectionPool'
 
-interface StreamRow extends RowDataPacket {
+export interface StreamRow extends RowDataPacket {
     id: string
     description: string | null
     peerCount: number
@@ -45,7 +45,7 @@ export class StreamRepository {
         orderDirection?: OrderDirection,
         pageSize?: number,
         cursor?: string
-    ): Promise<Streams> {
+    ): Promise<PaginatedListFragment<StreamRow>> {
         logger.info('Query: getStreams', { ids, searchTerm, owner, orderBy, orderDirection, pageSize, cursor })
         const whereClauses = []
         const params = []

--- a/src/repository/SummaryRepository.ts
+++ b/src/repository/SummaryRepository.ts
@@ -1,13 +1,12 @@
 import { Inject, Service } from 'typedi'
-import { Summary } from '../entities/Summary'
 import { ConnectionPool } from './ConnectionPool'
 
-interface StreamSummaryRow {
+export interface StreamSummaryRow {
     streamCount: number
     messagesPerSecond: number
 }
 
-interface NodeSummaryRow {
+export interface NodeSummaryRow {
     nodeCount: number
 } 
 
@@ -22,7 +21,7 @@ export class SummaryRepository {
         this.connectionPool = connectionPool
     }
 
-    async getSummary(): Promise<Summary> {
+    async getSummary(): Promise<StreamSummaryRow & NodeSummaryRow> {
         const streamSummaryRows = await this.connectionPool.queryOrExecute<StreamSummaryRow>(
             'SELECT count(*) as streamCount, sum(messagesPerSecond) as messagesPerSecond FROM streams'
         )

--- a/src/repository/SummaryRepository.ts
+++ b/src/repository/SummaryRepository.ts
@@ -24,10 +24,10 @@ export class SummaryRepository {
     }
 
     async getSummary(): Promise<Summary> {
-        const streamSummaryRows = await this.connectionPool.queryOrExecute<StreamSummaryRow[]>(
+        const streamSummaryRows = await this.connectionPool.queryOrExecute<StreamSummaryRow>(
             'SELECT count(*) as streamCount, sum(messagesPerSecond) as messagesPerSecond FROM streams'
         )
-        const nodeSummaryRows = await this.connectionPool.queryOrExecute<NodeSummaryRow[]>(
+        const nodeSummaryRows = await this.connectionPool.queryOrExecute<NodeSummaryRow>(
             'SELECT count(*) as nodeCount FROM nodes'
         )
         return {

--- a/src/repository/SummaryRepository.ts
+++ b/src/repository/SummaryRepository.ts
@@ -1,14 +1,13 @@
-import { RowDataPacket } from 'mysql2/promise'
 import { Inject, Service } from 'typedi'
 import { Summary } from '../entities/Summary'
 import { ConnectionPool } from './ConnectionPool'
 
-interface StreamSummaryRow extends RowDataPacket {
+interface StreamSummaryRow {
     streamCount: number
     messagesPerSecond: number
 }
 
-interface NodeSummaryRow extends RowDataPacket {
+interface NodeSummaryRow {
     nodeCount: number
 } 
 


### PR DESCRIPTION
`StreamRepository` and `SummaryRepository` now use `*Row` types as return type/parameter types. Previously GraphQL types were used. The similar separation was already done for `NodeRow` in https://github.com/streamr-dev/stream-metrics-index/pull/9.

Also simplified types of `ConnectionPool#queryOrExecute` and `PaginatedListFragment`. The the `*Row` types no longer extent RowDataPacket so that we use that in `StreamRepository#replaceStream`. Added also `crawlTimestamp` type field to `StreamRow` (the type system didn't need that earlier as `StreamRow` extended the `RowPacketData` which allowed any fields to be in the type).