### PR TITLE
feat: `Location#city` is optional

### DIFF
--- a/src/entities/Node.ts
+++ b/src/entities/Node.ts
@@ -18,8 +18,8 @@ export class Location {
     latitude!: number
     @Field(() => Float)
     longitude!: number
-    @Field()
-    city!: string
+    @Field(() => String, { nullable: true })
+    city!: string | null
     @Field()
     country!: string
 }

--- a/src/location.ts
+++ b/src/location.ts
@@ -7,7 +7,7 @@ export const getLocationFromIpAddress = (ipAddress: string): Location | undefine
         return {
             latitude: data.ll[0],
             longitude: data.ll[1],
-            city: data.city,
+            city: (data.city) !== '' ? (data.city) : null,
             country: data.country
         }
     } else {

--- a/test/location.test.ts
+++ b/test/location.test.ts
@@ -14,4 +14,13 @@ describe('getLocationFromIpAddress', () => {
     it('data unavailable', () => {
         expect(getLocationFromIpAddress('127.0.0.1')).toBeUndefined()
     })
+
+    it('no city', () => {
+        expect(getLocationFromIpAddress('1.2.3.4')).toEqual({
+            city: null,
+            country: 'AU',
+            latitude: -33.494,
+            longitude: 143.2104,
+        })
+    })
 })


### PR DESCRIPTION
We don't always get city information when we do a `geoip-lite` lookup. Therefore annotated the `city` field as optional.