### PR TITLE
feat: Query nodes by stream

### DIFF
--- a/src/api/NodeResolver.ts
+++ b/src/api/NodeResolver.ts
@@ -1,4 +1,4 @@
-import { StreamPartIDUtils } from '@streamr/protocol'
+import { StreamPartIDUtils, toStreamID } from '@streamr/protocol'
 import { DhtAddress } from '@streamr/sdk'
 import { DeepOmit } from 'ts-essentials'
 import { Arg, FieldResolver, Int, Query, Resolver, Root } from 'type-graphql'
@@ -22,11 +22,13 @@ export class NodeResolver {
     @Query(() => Nodes)
     async nodes(
         @Arg("ids", () => [String], { nullable: true }) ids?: string[],
+        @Arg("stream", { nullable: true }) streamId?: string,
         @Arg("pageSize", () => Int, { nullable: true }) pageSize?: number,
         @Arg("cursor", { nullable: true }) cursor?: string
     ): Promise<DeepOmit<Nodes, { items: { location: never }[] }>> {
         return this.repository.getNodes(
             (ids !== undefined) ? ids as DhtAddress[] : undefined,
+            (streamId !== undefined) ? toStreamID(streamId) : undefined,
             pageSize,
             cursor
         )

--- a/test/APIServer.test.ts
+++ b/test/APIServer.test.ts
@@ -274,9 +274,15 @@ describe('APIServer', () => {
 
         const node1 = createRandomDhtAddress()
         const node2 = createRandomDhtAddress()
+        const node3 = createRandomDhtAddress()
+        const node4 = createRandomDhtAddress()
 
         beforeEach(async () => {
-            await storeTestTopology([{ id: StreamPartIDUtils.parse('stream#0'), node1, node2 }])
+            await storeTestTopology([
+                { id: StreamPartIDUtils.parse('stream1#0'), node1, node2 },
+                { id: StreamPartIDUtils.parse('stream1#1'), node1: node3, node2: node4 },
+                { id: StreamPartIDUtils.parse('stream2#0'), node1: createRandomDhtAddress(), node2: createRandomDhtAddress() }
+            ])
         })
 
         it('ids', async () => {
@@ -305,6 +311,18 @@ describe('APIServer', () => {
                     longitude: 136.906
                 }
             })
+        })
+
+        it('stream', async () => {
+            const response = await queryAPI(`{
+                nodes(stream: "stream1") {
+                    items {
+                        id
+                    }
+                }
+            }`, apiPort)
+            const actualNodeIds = response.items.map((node: any) => node.id)
+            expect(actualNodeIds).toIncludeSameMembers([node1, node2, node3, node4])
         })
     }) 
 


### PR DESCRIPTION
Support this kind of query:
```graphql
nodes(stream: "streamId") {
  items {
     id
     ...
  }  
}
```