### PR TITLE
feat: Query neighbors by stream

### DIFF
--- a/src/api/NodeResolver.ts
+++ b/src/api/NodeResolver.ts
@@ -38,12 +38,14 @@ export class NodeResolver {
     async neighbors(
         @Arg("node", { nullable: true }) nodeId?: DhtAddress,
         @Arg("streamPart", { nullable: true }) streamPart?: string,
+        @Arg("stream", { nullable: true }) streamId?: string,
         @Arg("pageSize", () => Int, { nullable: true }) pageSize?: number,
         @Arg("cursor", { nullable: true }) cursor?: string
     ): Promise<Neighbors> {
         return this.repository.getNeighbors(
             (nodeId !== undefined) ? nodeId as DhtAddress : undefined,
             (streamPart !== undefined) ? StreamPartIDUtils.parse(streamPart) : undefined,
+            (streamId !== undefined) ? toStreamID(streamId) : undefined,
             pageSize,
             cursor
         )

--- a/src/repository/NodeRepository.ts
+++ b/src/repository/NodeRepository.ts
@@ -70,6 +70,7 @@ export class NodeRepository {
     async getNeighbors(
         nodeId?: DhtAddress,
         streamPartId?: StreamPartID,
+        streamId?: StreamID,
         pageSize?: number,
         cursor?: string
     ): Promise<PaginatedListFragment<NeighborRow>> {
@@ -83,6 +84,10 @@ export class NodeRepository {
         if (streamPartId !== undefined) {
             whereClauses.push('streamPartId = ?')
             params.push(streamPartId)
+        }
+        if (streamId !== undefined) {
+            whereClauses.push('streamPartId LIKE ?')
+            params.push(`${streamId}#%`)
         }
         const sql = createSqlQuery(
             'SELECT streamPartId, nodeId1, nodeId2 FROM neighbors',

--- a/test/APIServer.test.ts
+++ b/test/APIServer.test.ts
@@ -332,11 +332,14 @@ describe('APIServer', () => {
         const node2 = createRandomDhtAddress()
         const node3 = createRandomDhtAddress()
         const node4 = createRandomDhtAddress()
+        const node5 = createRandomDhtAddress()
+        const node6 = createRandomDhtAddress()
 
         beforeEach(async () => {
             await storeTestTopology([
-                { id: StreamPartIDUtils.parse('stream#0'), node1, node2 },
-                { id: StreamPartIDUtils.parse('stream#1'), node1: node3, node2: node4 }
+                { id: StreamPartIDUtils.parse('stream1#0'), node1, node2 },
+                { id: StreamPartIDUtils.parse('stream1#1'), node1: node3, node2: node4 },
+                { id: StreamPartIDUtils.parse('stream2#0'), node1: node5, node2: node6 }
             ])
         })
 
@@ -351,8 +354,8 @@ describe('APIServer', () => {
                 }
             }`, apiPort)
             const neighbors = response['items']
-            const actualNodes = [neighbors[0].nodeId1, neighbors[0].nodeId2, neighbors[1].nodeId1, neighbors[1].nodeId2]
-            expect(actualNodes).toIncludeSameMembers([node1, node2, node3, node4])
+            const actualNodes = neighbors.map((n: any) => [n.nodeId1, n.nodeId2]).flat()
+            expect(actualNodes).toIncludeSameMembers([node1, node2, node3, node4, node5, node6])
         })
 
         it('filter by node', async () => {
@@ -366,13 +369,13 @@ describe('APIServer', () => {
                 }
             }`, apiPort)
             const neighbors = response1['items']
-            const actualNodes = [neighbors[0].nodeId1, neighbors[0].nodeId2]
+            const actualNodes = neighbors.map((n: any) => [n.nodeId1, n.nodeId2]).flat()
             expect(actualNodes).toIncludeSameMembers([node1, node2])
         })
 
         it('filter by stream part', async () => {
             const response = await queryAPI(`{
-                neighbors(streamPart: "stream#0") {
+                neighbors(streamPart: "stream1#0") {
                     items {
                         nodeId1
                         nodeId2
@@ -380,8 +383,22 @@ describe('APIServer', () => {
                 }
             }`, apiPort)
             const neighbors = response['items']
-            const actualNodes = [neighbors[0].nodeId1, neighbors[0].nodeId2]
+            const actualNodes = neighbors.map((n: any) => [n.nodeId1, n.nodeId2]).flat()
             expect(actualNodes).toIncludeSameMembers([node1, node2])
+        })
+
+        it('filter by stream', async () => {
+            const response = await queryAPI(`{
+                neighbors(stream: "stream1") {
+                    items {
+                        nodeId1
+                        nodeId2
+                    }
+                }
+            }`, apiPort)
+            const neighbors = response['items']
+            const actualNodes = neighbors.map((n: any) => [n.nodeId1, n.nodeId2]).flat()
+            expect(actualNodes).toIncludeSameMembers([node1, node2, node3, node4])
         })
     })
 

--- a/test/APIServer.test.ts
+++ b/test/APIServer.test.ts
@@ -20,12 +20,7 @@ const storeTestTopology = async (
     }[]
 ) => {
     const nodeRepository = Container.get(NodeRepository)
-    const nodeIds: Set<DhtAddress> = new Set()
-    for (const streamPart of streamParts) {
-        for (const nodeId of streamPart.nodeIds) {
-            nodeIds.add(nodeId)
-        }
-    }
+    const nodeIds: Set<DhtAddress> = new Set(streamParts.map((sp) => sp.nodeIds).flat())
     const getNodes = () => {
         return [...nodeIds].map((nodeId: DhtAddress) => {
             const streamPartNeighbors = new Multimap()


### PR DESCRIPTION
Support this kind of query:
```graphql
neighbors(stream: "stream") {
  items {
    streamPartId
    nodeId1
    nodeId2
  } 
}
```

Note that if a nodes are neighbors in multiple stream parts, multiple items will be returned. E.g.:
```
stream#0, A, B
stream#1, A, B
```

Also improved API server unit test coverage by using duplicate nodeIds in some test topologies.