### PR TITLE
feat: [NET-1291] Add bytes per second metrics

### DIFF
--- a/initialize-database.sql
+++ b/initialize-database.sql
@@ -1,11 +1,11 @@
 CREATE TABLE IF NOT EXISTS streams (
     id VARCHAR(500) NOT NULL PRIMARY KEY,
     description TEXT,
-    peerCount INTEGER NOT NULL,
-    messagesPerSecond DECIMAL(8,2) NOT NULL,
-    bytesPerSecond DECIMAL(16,2) NOT NULL,
-    publisherCount INTEGER,  -- NULL if stream has public publish permission
-    subscriberCount INTEGER,  -- NULL if stream has public subscribe permission
+    peerCount INTEGER UNSIGNED NOT NULL,
+    messagesPerSecond DECIMAL(8,2) UNSIGNED NOT NULL,
+    bytesPerSecond DECIMAL(16,2) UNSIGNED NOT NULL,
+    publisherCount INTEGER UNSIGNED,  -- NULL if stream has public publish permission
+    subscriberCount INTEGER UNSIGNED,  -- NULL if stream has public subscribe permission
     crawlTimestamp DATETIME NOT NULL,
     INDEX streams_peerCount (peerCount),
     INDEX streams_description (description(100)),

--- a/initialize-database.sql
+++ b/initialize-database.sql
@@ -3,12 +3,14 @@ CREATE TABLE IF NOT EXISTS streams (
     description TEXT,
     peerCount INTEGER NOT NULL,
     messagesPerSecond DECIMAL(8,2) NOT NULL,
+    bytesPerSecond DECIMAL(16,2) NOT NULL,
     publisherCount INTEGER,  -- NULL if stream has public publish permission
     subscriberCount INTEGER,  -- NULL if stream has public subscribe permission
     crawlTimestamp DATETIME NOT NULL,
     INDEX streams_peerCount (peerCount),
     INDEX streams_description (description(100)),
     INDEX streams_messagesPerSecond (messagesPerSecond),
+    INDEX streams_bytesPerSecond (bytesPerSecond),
     INDEX streams_publisherCount (publisherCount),
     INDEX streams_subscriberCount (subscriberCount)
 );

--- a/src/crawler/Crawler.ts
+++ b/src/crawler/Crawler.ts
@@ -191,7 +191,7 @@ export class Crawler {
         }
         try {
             const peerIds = new Set(...peersByPartition.values())
-            const messagesPerSecond = (peerIds.size > 0)
+            const messageRate = (peerIds.size > 0)
                 ? await getMessageRate(
                     id, 
                     [...peersByPartition.keys()],
@@ -199,7 +199,7 @@ export class Crawler {
                     subscribeGate,
                     this.config
                 )
-                : 0
+                : { messagesPerSecond: 0, bytesPerSecond: 0 }
             const publisherCount = await this.client.getPublisherOrSubscriberCount(id, StreamPermission.PUBLISH)
             const subscriberCount = await this.client.getPublisherOrSubscriberCount(id, StreamPermission.SUBSCRIBE)
             logger.info(`Replace ${id}`)
@@ -207,7 +207,8 @@ export class Crawler {
                 id,
                 description: metadata.description ?? null,
                 peerCount: peerIds.size,
-                messagesPerSecond,
+                messagesPerSecond: messageRate.messagesPerSecond,
+                bytesPerSecond: messageRate.bytesPerSecond,
                 publisherCount,
                 subscriberCount
             })
@@ -244,6 +245,7 @@ export class Crawler {
                 description: payload.metadata.description ?? null,
                 peerCount: 0,
                 messagesPerSecond: 0,
+                bytesPerSecond: 0,
                 publisherCount: 1,
                 subscriberCount: 1
             })

--- a/src/entities/Stream.ts
+++ b/src/entities/Stream.ts
@@ -11,6 +11,8 @@ export class Stream {
     peerCount!: number
     @Field(() => Float)
     messagesPerSecond!: number
+    @Field(() => Float)
+    bytesPerSecond!: number
     @Field(() => Int, { nullable: true })
     publisherCount!: number | null
     @Field(() => Int, { nullable: true })
@@ -22,6 +24,7 @@ export enum StreamOrderBy {
     DESCRIPTION = 'DESCRIPTION',
     PEER_COUNT = 'PEER_COUNT',
     MESSAGES_PER_SECOND = 'MESSAGES_PER_SECOND',
+    BYTES_PER_SECOND = 'BYTES_PER_SECOND',
     SUBSCRIBER_COUNT = 'SUBSCRIBER_COUNT',
     PUBLISHER_COUNT = 'PUBLISHER_COUNT'
 }

--- a/src/entities/Summary.ts
+++ b/src/entities/Summary.ts
@@ -7,6 +7,8 @@ export class Summary {
     streamCount!: number
     @Field(() => Float)
     messagesPerSecond!: number
+    @Field(() => Float)
+    bytesPerSecond!: number
     @Field(() => Int)
     nodeCount!: number
 }

--- a/src/repository/StreamRepository.ts
+++ b/src/repository/StreamRepository.ts
@@ -12,6 +12,7 @@ export interface StreamRow {
     description: string | null
     peerCount: number
     messagesPerSecond: number
+    bytesPerSecond: number
     publisherCount: number | null
     subscriberCount: number | null
     crawlTimestamp: string
@@ -68,7 +69,7 @@ export class StreamRepository {
             params.push(streamIds)
         }
         const sql = createSqlQuery(
-            'SELECT id, description, peerCount, messagesPerSecond, publisherCount, subscriberCount FROM streams',
+            'SELECT id, description, peerCount, messagesPerSecond, bytesPerSecond, publisherCount, subscriberCount FROM streams',
             whereClauses,
             StreamRepository.formOrderByExpression(orderBy ?? StreamOrderBy.ID, orderDirection ?? OrderDirection.ASC)
         )
@@ -86,6 +87,8 @@ export class StreamRepository {
                     return 'peerCount'
                 case StreamOrderBy.MESSAGES_PER_SECOND:
                     return 'messagesPerSecond'
+                case StreamOrderBy.BYTES_PER_SECOND:
+                    return 'bytesPerSecond'
                 case StreamOrderBy.PUBLISHER_COUNT:
                     return 'publisherCount'
                 case StreamOrderBy.SUBSCRIBER_COUNT:
@@ -132,11 +135,27 @@ export class StreamRepository {
     async replaceStream(stream: Omit<StreamRow, 'crawlTimestamp'>): Promise<void> {
         await this.connectionPool.queryOrExecute(
             `REPLACE INTO streams (
-                id, description, peerCount, messagesPerSecond, publisherCount, subscriberCount, crawlTimestamp
+                id,
+                description,
+                peerCount,
+                messagesPerSecond,
+                bytesPerSecond,
+                publisherCount,
+                subscriberCount,
+                crawlTimestamp
             ) VALUES (
-                ?, ?, ?, ?, ?, ?, ?
+                ?, ?, ?, ?, ?, ?, ?, ?
             )`,
-            [stream.id, stream.description, stream.peerCount, stream.messagesPerSecond, stream.publisherCount, stream.subscriberCount, new Date()]
+            [
+                stream.id,
+                stream.description,
+                stream.peerCount,
+                stream.messagesPerSecond,
+                stream.bytesPerSecond,
+                stream.publisherCount,
+                stream.subscriberCount,
+                new Date()
+            ]
         )
     }
 }

--- a/src/repository/SummaryRepository.ts
+++ b/src/repository/SummaryRepository.ts
@@ -4,6 +4,7 @@ import { ConnectionPool } from './ConnectionPool'
 export interface StreamSummaryRow {
     streamCount: number
     messagesPerSecond: number
+    bytesPerSecond: number
 }
 
 export interface NodeSummaryRow {
@@ -23,7 +24,7 @@ export class SummaryRepository {
 
     async getSummary(): Promise<StreamSummaryRow & NodeSummaryRow> {
         const streamSummaryRows = await this.connectionPool.queryOrExecute<StreamSummaryRow>(
-            'SELECT count(*) as streamCount, sum(messagesPerSecond) as messagesPerSecond FROM streams'
+            'SELECT count(*) as streamCount, sum(messagesPerSecond) as messagesPerSecond, sum(bytesPerSecond) as bytesPerSecond FROM streams'
         )
         const nodeSummaryRows = await this.connectionPool.queryOrExecute<NodeSummaryRow>(
             'SELECT count(*) as nodeCount FROM nodes'

--- a/test/APIServer.test.ts
+++ b/test/APIServer.test.ts
@@ -76,6 +76,7 @@ describe('APIServer', () => {
                 description: '',
                 peerCount: 123,
                 messagesPerSecond: 4.5,
+                bytesPerSecond: 450,
                 publisherCount: 6,
                 subscriberCount: 7
             }
@@ -87,6 +88,7 @@ describe('APIServer', () => {
                         description
                         peerCount
                         messagesPerSecond
+                        bytesPerSecond
                         publisherCount
                         subscriberCount
                     }
@@ -103,6 +105,7 @@ describe('APIServer', () => {
                     description: '',
                     peerCount: 123,
                     messagesPerSecond: 4.56,
+                    bytesPerSecond: 456,
                     publisherCount: null,
                     subscriberCount: null
                 }
@@ -132,6 +135,7 @@ describe('APIServer', () => {
                 description: '',
                 peerCount: 123,
                 messagesPerSecond: 200,
+                bytesPerSecond: 20000,
                 publisherCount: null,
                 subscriberCount: 20
             })
@@ -140,6 +144,7 @@ describe('APIServer', () => {
                 description: '',
                 peerCount: 456,
                 messagesPerSecond: 100,
+                bytesPerSecond: 10000,
                 publisherCount: 10,
                 subscriberCount: 10
             })           
@@ -148,6 +153,7 @@ describe('APIServer', () => {
                 description: '',
                 peerCount: 789,
                 messagesPerSecond: 300,
+                bytesPerSecond: 30000,
                 publisherCount: 20,
                 subscriberCount: null
             })
@@ -164,6 +170,7 @@ describe('APIServer', () => {
             expect(await queryOrderedStreams('ID', 'ASC')).toEqual(['id-1', 'id-2', 'id-3'])
             expect(await queryOrderedStreams('PEER_COUNT', 'DESC')).toEqual(['id-3', 'id-2', 'id-1'])
             expect(await queryOrderedStreams('MESSAGES_PER_SECOND', 'DESC')).toEqual(['id-3', 'id-1', 'id-2'])
+            expect(await queryOrderedStreams('BYTES_PER_SECOND', 'DESC')).toEqual(['id-3', 'id-1', 'id-2'])
             expect(await queryOrderedStreams('PUBLISHER_COUNT', 'DESC')).toEqual(['id-1', 'id-3', 'id-2'])
             expect(await queryOrderedStreams('SUBSCRIBER_COUNT', 'DESC')).toEqual(['id-3', 'id-1', 'id-2'])
         })
@@ -176,6 +183,7 @@ describe('APIServer', () => {
             description: '',
             peerCount: 0,
             messagesPerSecond: 0,
+            bytesPerSecond: 0,
             publisherCount: null,
             subscriberCount: null
         })
@@ -184,6 +192,7 @@ describe('APIServer', () => {
             description: '',
             peerCount: 0,
             messagesPerSecond: 0,
+            bytesPerSecond: 0,
             publisherCount: null,
             subscriberCount: null
         })
@@ -211,6 +220,7 @@ describe('APIServer', () => {
             description: '',
             peerCount: 111,
             messagesPerSecond: 10,
+            bytesPerSecond: 1000,
             publisherCount: 1,
             subscriberCount: 1
         }
@@ -220,6 +230,7 @@ describe('APIServer', () => {
             description: '',
             peerCount: 222,
             messagesPerSecond: 20,
+            bytesPerSecond: 2000,
             publisherCount: 2,
             subscriberCount: 2
         })
@@ -230,6 +241,7 @@ describe('APIServer', () => {
                     description
                     peerCount
                     messagesPerSecond
+                    bytesPerSecond
                     publisherCount
                     subscriberCount
                 }
@@ -247,6 +259,7 @@ describe('APIServer', () => {
                 description: `description-${i}`,
                 peerCount: 0,
                 messagesPerSecond: 0,
+                bytesPerSecond: 0,
                 publisherCount: null,
                 subscriberCount: null
             }
@@ -406,6 +419,7 @@ describe('APIServer', () => {
             description: '',
             peerCount: 10,
             messagesPerSecond: 100,
+            bytesPerSecond: 10000,
             publisherCount: null,
             subscriberCount: null
         })
@@ -414,6 +428,7 @@ describe('APIServer', () => {
             description: '',
             peerCount: 20,
             messagesPerSecond: 200,
+            bytesPerSecond: 20000,
             publisherCount: null,
             subscriberCount: null
         })
@@ -422,12 +437,14 @@ describe('APIServer', () => {
             summary {
                 streamCount
                 messagesPerSecond
+                bytesPerSecond
                 nodeCount
             }
         }`, apiPort)
         expect(summary).toEqual({
             streamCount: 2,
             messagesPerSecond: 300,
+            bytesPerSecond: 30000,
             nodeCount: 2
         })
     })

--- a/test/end-to-end.test.ts
+++ b/test/end-to-end.test.ts
@@ -82,6 +82,7 @@ const queryStreamMetrics = async (id: string, apiPort: number): Promise<Stream |
                 description
                 peerCount
                 messagesPerSecond
+                bytesPerSecond
                 publisherCount
                 subscriberCount
             }
@@ -216,6 +217,7 @@ describe('end-to-end', () => {
         expect(streamMetrics1.description).toBe('mock-description')
         expect(streamMetrics1.peerCount).toBe(2)
         expect(streamMetrics1.messagesPerSecond).toBeGreaterThan(0)
+        expect(streamMetrics1.bytesPerSecond).toBeGreaterThan(0)
         expect(streamMetrics1.publisherCount).toBe(1)
         expect(streamMetrics1.subscriberCount).toBe(2)
 
@@ -244,6 +246,7 @@ describe('end-to-end', () => {
         expect(streamMetrics2.description).toBe('mock-description')
         expect(streamMetrics2.peerCount).toBe(2)
         expect(streamMetrics2.messagesPerSecond).toBeGreaterThan(0)
+        expect(streamMetrics2.bytesPerSecond).toBeGreaterThan(0)
         expect(streamMetrics2.publisherCount).toBe(1)
         expect(streamMetrics2.subscriberCount).toBe(2)
 

--- a/test/messageRate.test.ts
+++ b/test/messageRate.test.ts
@@ -4,10 +4,12 @@ import { range } from 'lodash'
 import { MAX_PARTITION_COUNT, getMessageRate } from '../src/crawler/messageRate'
 
 const STREAM_ID = toStreamID('stream-id')
+const CONTENT_LENGTH = 100
 
 const createMockMessage = (): Partial<StreamMessage> => {
     return {
-        getStreamId: () => STREAM_ID
+        getStreamId: () => STREAM_ID,
+        content: new Uint8Array(range(CONTENT_LENGTH))
     }
 }
 
@@ -38,7 +40,8 @@ describe('messageRate', () => {
                 subscribeDuration: 200
             }
         } as any)
-        expect(actual).toEqual(15)
+        expect(actual.messagesPerSecond).toEqual(15)
+        expect(actual.bytesPerSecond).toEqual(1500)
         expect(node.subscribe).toBeCalledTimes(3)
         expect(node.subscribe.mock.calls.flat().sort()).toEqual([
             toStreamPartID(STREAM_ID, 1),
@@ -56,7 +59,8 @@ describe('messageRate', () => {
                 subscribeDuration: 200
             }
         } as any)
-        expect(actual).toEqual(15 * partitionMultiplier)
+        expect(actual.messagesPerSecond).toEqual(15 * partitionMultiplier)
+        expect(actual.bytesPerSecond).toEqual(1500 * partitionMultiplier)
         expect(node.subscribe).toBeCalledTimes(MAX_PARTITION_COUNT)
     })
 })


### PR DESCRIPTION
Collect `bytesPerSecond` metrics for all streams. The field is queryable via the `streams` entity. There is also a related field in the `summary` entity.

Also changed `streams` database table to to use `unsigned` column types.