### PR TITLE
feat: [NET-1290]: Store sample message

### DIFF
--- a/initialize-database.sql
+++ b/initialize-database.sql
@@ -15,6 +15,12 @@ CREATE TABLE IF NOT EXISTS streams (
     INDEX streams_subscriberCount (subscriberCount)
 );
 
+CREATE TABLE IF NOT EXISTS sample_messages (
+    streamId VARCHAR(500) NOT NULL PRIMARY KEY,
+    content MEDIUMBLOB NOT NULL,
+    contentType VARCHAR(6) NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS nodes (
     id CHAR(40) NOT NULL PRIMARY KEY,
     ipAddress VARCHAR(15)

--- a/initialize-database.sql
+++ b/initialize-database.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS streams (
 CREATE TABLE IF NOT EXISTS sample_messages (
     streamId VARCHAR(500) NOT NULL PRIMARY KEY,
     content MEDIUMBLOB NOT NULL,
-    contentType VARCHAR(6) NOT NULL
+    contentType VARCHAR(50) NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS nodes (

--- a/src/api/APIServer.ts
+++ b/src/api/APIServer.ts
@@ -11,6 +11,7 @@ import { Config, CONFIG_TOKEN } from '../Config'
 import { StreamResolver } from './StreamResolver'
 import { SummaryResolver } from './SummaryResolver'
 import { NodeResolver } from './NodeResolver'
+import { MessageResolver } from './MessageResolver'
 
 const logger = new Logger(module)
 
@@ -30,7 +31,7 @@ export class APIServer {
 
     async start(): Promise<void> {
         const schema = await buildSchema({
-            resolvers: [StreamResolver, NodeResolver, SummaryResolver],
+            resolvers: [StreamResolver, MessageResolver, NodeResolver, SummaryResolver],
             container: Container,
             validate: false
         })

--- a/src/api/MessageResolver.ts
+++ b/src/api/MessageResolver.ts
@@ -1,0 +1,36 @@
+import { Arg, Query, Resolver } from 'type-graphql'
+import { Inject, Service } from 'typedi'
+import { ContentType, Message } from '../entities/Message'
+import { MessageRepository } from '../repository/MessageRepository'
+import { toStreamID } from '@streamr/protocol'
+import { binaryToUtf8 } from '@streamr/utils'
+
+@Resolver()
+@Service()
+export class MessageResolver {
+
+    private repository: MessageRepository
+
+    constructor(
+        @Inject() repository: MessageRepository
+    ) {
+        this.repository = repository
+    }
+
+    @Query(() => Message, { nullable: true })
+    async sampleMessage(
+        @Arg("stream", { nullable: false }) streamId: string
+    ): Promise<Message | null> {
+        const message = await this.repository.getSampleMessage(toStreamID(streamId))
+        if (message !== null) {
+            return {
+                content: (message.contentType === ContentType.JSON)
+                    ? binaryToUtf8(message.content)
+                    : Buffer.from(message.content).toString('base64'),
+                contentType: message.contentType
+            }
+        } else {
+            return null
+        }
+    }
+}

--- a/src/entities/Message.ts
+++ b/src/entities/Message.ts
@@ -1,0 +1,15 @@
+import { Field, ObjectType } from 'type-graphql'
+
+export enum ContentType {
+    JSON = 'JSON',
+    BINARY = 'BINARY'
+}
+
+/* eslint-disable indent */
+@ObjectType()
+export class Message {
+    @Field(() => String, { description: 'JSON string if contentType is JSON, otherwise base64-encoded binary content' })
+    content!: string
+    @Field()
+    contentType!: ContentType
+}

--- a/src/repository/MessageRepository.ts
+++ b/src/repository/MessageRepository.ts
@@ -1,0 +1,67 @@
+import { Inject, Service } from 'typedi'
+import { ConnectionPool } from './ConnectionPool'
+import { StreamID } from '@streamr/protocol'
+import { ContentType } from '../entities/Message'
+import { StreamMessage, ContentType as StreamMessageContentType } from '@streamr/protocol'
+
+export interface MessageRow {
+    content: Uint8Array
+    contentType: ContentType
+}
+
+export const convertStreamMessageToMessageRow = (msg: StreamMessage): MessageRow => {
+    let contentType
+    if (msg.contentType === StreamMessageContentType.JSON) {
+        contentType = ContentType.JSON
+    } else if (msg.contentType === StreamMessageContentType.BINARY) {
+        contentType = ContentType.BINARY
+    } else {
+        throw new Error(`Assertion failed: unknown content type ${msg.contentType}`)
+    }
+    return { 
+        content: msg.content,
+        contentType
+    }
+}
+
+@Service()
+export class MessageRepository {
+
+    private readonly connectionPool: ConnectionPool
+
+    constructor(
+        @Inject() connectionPool: ConnectionPool
+    ) {
+        this.connectionPool = connectionPool
+    }
+
+    async getSampleMessage(streamId: StreamID): Promise<MessageRow | null> {
+        const rows = await this.connectionPool.queryOrExecute<MessageRow>(
+            'SELECT content, contentType FROM sample_messages WHERE streamId=? LIMIT 1',
+            [streamId]
+        )
+        if (rows.length === 1) {
+            return rows[0]
+        } else {
+            return null
+        }
+    }
+
+    async replaceSampleMessage(message: MessageRow | null, streamId: StreamID): Promise<void> {
+        if (message !== null) {
+            await this.connectionPool.queryOrExecute(
+                'REPLACE INTO sample_messages (streamId, content, contentType) VALUES (?, ?, ?)',
+                [
+                    streamId,
+                    Buffer.from(message.content),
+                    message.contentType
+                ]
+            )
+        } else {
+            await this.connectionPool.queryOrExecute(
+                'DELETE FROM sample_messages WHERE streamId=?',
+                [streamId]
+            )
+        }
+    }
+}

--- a/test/APIServer.test.ts
+++ b/test/APIServer.test.ts
@@ -10,8 +10,11 @@ import { createDatabase, queryAPI } from '../src/utils'
 import { dropTestDatabaseIfExists, TEST_DATABASE_NAME } from './utils'
 import { NodeRepository } from '../src/repository/NodeRepository'
 import { DhtAddress, createRandomDhtAddress } from '@streamr/dht'
-import { Multimap } from '@streamr/utils'
+import { Multimap, utf8ToBinary } from '@streamr/utils'
 import { StreamPartID, StreamPartIDUtils } from '@streamr/protocol'
+import { MessageRepository } from '../src/repository/MessageRepository'
+import { ContentType } from '../src/entities/Message'
+import { StreamID } from '@streamr/protocol'
 
 const storeTestTopology = async (
     streamParts: {
@@ -280,6 +283,58 @@ describe('APIServer', () => {
             id: 'id-3',
             description: 'description-3'
         }])
+    })
+
+    describe('sampleMessage', () => {
+
+        it('JSON', async () => {
+            const streamId = `stream-${Date.now()}` as StreamID
+            const repository = Container.get(MessageRepository)
+            await repository.replaceSampleMessage({
+                content: utf8ToBinary('mock-json-content'),
+                contentType: ContentType.JSON
+            }, streamId)
+            const sample = await queryAPI(`{
+                sampleMessage(stream: "${streamId}") {
+                    content
+                    contentType
+                }
+            }`, apiPort)
+            expect(sample).toEqual({
+                content: 'mock-json-content',
+                contentType: 'JSON'
+            })
+        })
+
+        it('binary', async () => {
+            const streamId = `stream-${Date.now()}` as StreamID
+            const repository = Container.get(MessageRepository)
+            await repository.replaceSampleMessage({
+                content: new Uint8Array([1, 2, 3, 4]),
+                contentType: ContentType.BINARY
+            }, streamId)
+            const sample = await queryAPI(`{
+                sampleMessage(stream: "${streamId}") {
+                    content
+                    contentType
+                }
+            }`, apiPort)
+            expect(sample).toEqual({
+                content: 'AQIDBA==',
+                contentType: 'BINARY'
+            })
+        })
+
+        it('not found', async () => {
+            const streamId = `stream-${Date.now()}` as StreamID
+            const sample = await queryAPI(`{
+                sampleMessage(stream: "${streamId}") {
+                    content
+                    contentType
+                }
+            }`, apiPort)
+            expect(sample).toBeNull()
+        })
     })
 
     describe('nodes', () => {

--- a/test/APIServer.test.ts
+++ b/test/APIServer.test.ts
@@ -289,9 +289,10 @@ describe('APIServer', () => {
 
         it('JSON', async () => {
             const streamId = `stream-${Date.now()}` as StreamID
+            const content = { foo: 'bar' }
             const repository = Container.get(MessageRepository)
             await repository.replaceSampleMessage({
-                content: utf8ToBinary('mock-json-content'),
+                content: utf8ToBinary(JSON.stringify(content)),
                 contentType: ContentType.JSON
             }, streamId)
             const sample = await queryAPI(`{
@@ -301,7 +302,7 @@ describe('APIServer', () => {
                 }
             }`, apiPort)
             expect(sample).toEqual({
-                content: 'mock-json-content',
+                content: JSON.stringify(content),
                 contentType: 'JSON'
             })
         })

--- a/test/MessageRepository.test.ts
+++ b/test/MessageRepository.test.ts
@@ -1,0 +1,71 @@
+import 'reflect-metadata'
+
+import Container from 'typedi'
+import { CONFIG_TOKEN } from '../src/Config'
+import { createDatabase } from '../src/utils'
+import { TEST_DATABASE_NAME, dropTestDatabaseIfExists } from './utils'
+import { StreamID } from '@streamr/protocol'
+import { MessageRepository, MessageRow } from '../src/repository/MessageRepository'
+import { utf8ToBinary } from '@streamr/utils'
+import { ContentType } from '../src/entities/Message'
+
+const createTestMessage = (msg: { content: Uint8Array, contentType: ContentType }): MessageRow => {
+    return {
+        // normalize content to Buffer so that we can compare instances with expect().toEqual()
+        content: Buffer.from(msg.content),
+        contentType: msg.contentType
+    }
+}
+
+describe('MessageRepository', () => {
+
+    beforeEach(async () => {
+        const config = {
+            database: {
+                host: '10.200.10.1',
+                name: TEST_DATABASE_NAME,
+                user: 'root',
+                password: 'password'
+            }
+        }
+        await dropTestDatabaseIfExists(config.database)
+        await createDatabase(config.database)
+        Container.set(CONFIG_TOKEN, config)
+    })
+
+    afterEach(() => {
+        Container.reset()
+    })
+
+    it('create, update, remove', async () => {
+        const streamId = `stream-${Date.now()}` as StreamID
+        const otherStreamId = `other-stream-${Date.now()}` as StreamID
+        const repository = Container.get(MessageRepository)
+
+        // create
+        const sample1 = createTestMessage({
+            content: utf8ToBinary('stream-mock-json-content'),
+            contentType: ContentType.JSON
+        })
+        await repository.replaceSampleMessage(sample1, streamId)
+        const otherSample = createTestMessage({
+            content: utf8ToBinary('other-stream-mock-json-content'),
+            contentType: ContentType.JSON
+        })
+        await repository.replaceSampleMessage(otherSample, otherStreamId)
+        expect(await repository.getSampleMessage(streamId)).toEqual(sample1)
+
+        // update
+        const sample2 = createTestMessage({
+            content: new Uint8Array([1, 2, 3]),
+            contentType: ContentType.BINARY
+        })
+        await repository.replaceSampleMessage(sample2, streamId)
+        expect(await repository.getSampleMessage(streamId)).toEqual(sample2)
+
+        // delete
+        await repository.replaceSampleMessage(null, streamId)
+        expect(await repository.getSampleMessage(streamId)).toBeNull()
+        expect(await repository.getSampleMessage(otherStreamId)).toEqual(otherSample)
+    })
+})

--- a/test/end-to-end.test.ts
+++ b/test/end-to-end.test.ts
@@ -157,7 +157,7 @@ describe('end-to-end', () => {
         })
         const permissions = [StreamPermission.SUBSCRIBE]
         if (isPublic) {
-            await stream.grantPermissions({ public: true, permissions  })
+            await stream.grantPermissions({ public: true, permissions })
         }  else {
             await stream.grantPermissions({ user: await subscriber.getAddress(), permissions })
         }

--- a/test/end-to-end.test.ts
+++ b/test/end-to-end.test.ts
@@ -14,6 +14,7 @@ import { Node } from '../src/entities/Node'
 import { Stream } from '../src/entities/Stream'
 import { createDatabase, queryAPI } from '../src/utils'
 import { TEST_DATABASE_NAME, dropTestDatabaseIfExists } from './utils'
+import { Message } from '../src/entities/Message'
 
 const PUBLISHER_PRIVATE_KEY = '0x0000000000000000000000000000000000000000000000000000000000000001'
 const SUBSCRIBER_PRIVATE_KEY = '0x0000000000000000000000000000000000000000000000000000000000000002'
@@ -97,6 +98,17 @@ const queryStreamMetrics = async (id: string, apiPort: number): Promise<Stream |
     }
 }
 
+const querySampleMessage = async (streamId: string, apiPort: number): Promise<Message | undefined> => {
+    const query = `{
+        sampleMessage(stream: "${streamId}") {
+            content
+            contentType
+        }
+    }`
+    const response = await queryAPI(query, apiPort)
+    return response ?? undefined
+}
+
 const queryNodes = async (apiPort: number): Promise<Node[]> => {
     const query = `{
         nodes {
@@ -137,28 +149,30 @@ describe('end-to-end', () => {
     let crawler: Crawler
     let apiPort: number
 
-    const createTestStream = async () => {
+    const createTestStream = async (isPublic: boolean) => {
         const stream = await publisher.createStream({ 
             id: `/test/stream-metrics-index/${Date.now()}`,
             partitions: PARTITION_COUNT,
             description: 'mock-description'
         })
-        await stream.grantPermissions({
-            user: await subscriber.getAddress(),
-            permissions: [StreamPermission.SUBSCRIBE]
-        })
+        const permissions = [StreamPermission.SUBSCRIBE]
+        if (isPublic) {
+            await stream.grantPermissions({ public: true, permissions  })
+        }  else {
+            await stream.grantPermissions({ user: await subscriber.getAddress(), permissions })
+        }
         return stream
     }
 
     const startPublisherAndSubscriberForStream = async (streamId: StreamID, publishingAbortControler: AbortSignal) => {
-        return Promise.all(range(ACTIVE_PARTITION_COUNT).map(async (partition) => {
+        return Promise.all(range(ACTIVE_PARTITION_COUNT).map(async (partition: number) => {
             const streamPartDefinition = {
                 streamId: streamId,
                 partition
             }
             const subscription = await subscriber.subscribe(streamPartDefinition)
             setAbortableInterval(async () => {
-                await publisher.publish(streamPartDefinition, { foo: Date.now() })
+                await publisher.publish(streamPartDefinition, { foo: 'bar' })
             }, 500, publishingAbortControler)
             // wait until publisher and subscriber are connected
             const iterator = subscription[Symbol.asyncIterator]()
@@ -206,20 +220,38 @@ describe('end-to-end', () => {
     it('happy path', async () => {
         const publishingAbortControler = new AbortController()
 
-        const existingStream = await createTestStream()
-        await startPublisherAndSubscriberForStream(existingStream.id, publishingAbortControler.signal)
+        const privateStream = await createTestStream(false)
+        await startPublisherAndSubscriberForStream(privateStream.id, publishingAbortControler.signal)
+        const publicStream = await createTestStream(true)
+        await startPublisherAndSubscriberForStream(publicStream.id, publishingAbortControler.signal)
 
         crawler = Container.get(Crawler)
         await crawler.start(1)
 
-        const streamMetrics1 = (await queryStreamMetrics(existingStream.id, apiPort))!
-        expect(streamMetrics1.id).toBe(existingStream.id)
+        const streamMetrics1 = (await queryStreamMetrics(privateStream.id, apiPort))!
+        expect(streamMetrics1.id).toBe(privateStream.id)
         expect(streamMetrics1.description).toBe('mock-description')
         expect(streamMetrics1.peerCount).toBe(2)
         expect(streamMetrics1.messagesPerSecond).toBeGreaterThan(0)
         expect(streamMetrics1.bytesPerSecond).toBeGreaterThan(0)
         expect(streamMetrics1.publisherCount).toBe(1)
         expect(streamMetrics1.subscriberCount).toBe(2)
+
+        const sampleMessage1 = (await querySampleMessage(privateStream.id, apiPort))
+        expect(sampleMessage1).toBeUndefined()
+
+        const streamMetrics2 = (await queryStreamMetrics(publicStream.id, apiPort))!
+        expect(streamMetrics2.id).toBe(publicStream.id)
+        expect(streamMetrics2.description).toBe('mock-description')
+        expect(streamMetrics2.peerCount).toBe(2)
+        expect(streamMetrics2.messagesPerSecond).toBeGreaterThan(0)
+        expect(streamMetrics2.bytesPerSecond).toBeGreaterThan(0)
+        expect(streamMetrics2.publisherCount).toBe(1)
+        expect(streamMetrics2.subscriberCount).toBe(null)
+
+        const sampleMessage2 = (await querySampleMessage(publicStream.id, apiPort))!
+        expect(sampleMessage2.content).toEqual('{"foo":"bar"}')
+        expect(sampleMessage2.contentType).toEqual('JSON')
 
         const nodes = (await queryNodes(apiPort))!
         expect(nodes.map((n) => n.id)).toIncludeSameMembers([
@@ -230,25 +262,25 @@ describe('end-to-end', () => {
         ])
         expect(uniq(nodes.map((n) => n.ipAddress))).toEqual([DOCKER_DEV_LOOPBACK_IP_ADDRESS])
 
-        const randomActiveStreamPartId = toStreamPartID(existingStream.id, random(ACTIVE_PARTITION_COUNT - 1))
+        const randomActiveStreamPartId = toStreamPartID(privateStream.id, random(ACTIVE_PARTITION_COUNT - 1))
         const neighbors = (await queryNeighbors(await publisher.getNodeId(), randomActiveStreamPartId, apiPort))!
         expect(neighbors).toEqual([await subscriber.getNodeId()])
 
-        const newStream = await createTestStream()
+        const newStream = await createTestStream(false)
         await startPublisherAndSubscriberForStream(newStream.id, publishingAbortControler.signal)
 
         await waitForCondition(async () => {
             const metrics = await queryStreamMetrics(newStream.id, apiPort)
             return (metrics !== undefined) && (metrics.peerCount >= 2)
         }, 20 * 1000, 1000)
-        const streamMetrics2 = (await queryStreamMetrics(newStream.id, apiPort))!
-        expect(streamMetrics2.id).toBe(newStream.id)
-        expect(streamMetrics2.description).toBe('mock-description')
-        expect(streamMetrics2.peerCount).toBe(2)
-        expect(streamMetrics2.messagesPerSecond).toBeGreaterThan(0)
-        expect(streamMetrics2.bytesPerSecond).toBeGreaterThan(0)
-        expect(streamMetrics2.publisherCount).toBe(1)
-        expect(streamMetrics2.subscriberCount).toBe(2)
+        const streamMetrics3 = (await queryStreamMetrics(newStream.id, apiPort))!
+        expect(streamMetrics3.id).toBe(newStream.id)
+        expect(streamMetrics3.description).toBe('mock-description')
+        expect(streamMetrics3.peerCount).toBe(2)
+        expect(streamMetrics3.messagesPerSecond).toBeGreaterThan(0)
+        expect(streamMetrics3.bytesPerSecond).toBeGreaterThan(0)
+        expect(streamMetrics3.publisherCount).toBe(1)
+        expect(streamMetrics3.subscriberCount).toBe(2)
 
         publishingAbortControler.abort()
         crawler.stop()

--- a/test/messageRate.test.ts
+++ b/test/messageRate.test.ts
@@ -35,13 +35,14 @@ const createMockNode = (): any => {
 describe('messageRate', () => {
     it('happy path', async () => {
         const node = createMockNode()
-        const actual = await getMessageRate(STREAM_ID, [1, 4, 5], node, new Gate(true), {
+        const actual = await getMessageRate(STREAM_ID, [1, 4, 5], true, node, new Gate(true), {
             crawler: {
                 subscribeDuration: 200
             }
         } as any)
         expect(actual.messagesPerSecond).toEqual(15)
         expect(actual.bytesPerSecond).toEqual(1500)
+        expect(actual.sampleMessage).toBeDefined()
         expect(node.subscribe).toBeCalledTimes(3)
         expect(node.subscribe.mock.calls.flat().sort()).toEqual([
             toStreamPartID(STREAM_ID, 1),
@@ -54,13 +55,14 @@ describe('messageRate', () => {
         const partitionMultiplier = 4
         const partitions = range(MAX_PARTITION_COUNT * partitionMultiplier)
         const node = createMockNode()
-        const actual = await getMessageRate(STREAM_ID, partitions, node, new Gate(true), {
+        const actual = await getMessageRate(STREAM_ID, partitions, true, node, new Gate(true), {
             crawler: {
                 subscribeDuration: 200
             }
         } as any)
         expect(actual.messagesPerSecond).toEqual(15 * partitionMultiplier)
         expect(actual.bytesPerSecond).toEqual(1500 * partitionMultiplier)
+        expect(actual.sampleMessage).toBeDefined()
         expect(node.subscribe).toBeCalledTimes(MAX_PARTITION_COUNT)
     })
 })


### PR DESCRIPTION
Added new `sampleMessage` endpoint. It returns a sample message from a specified stream. 

- In each crawl iteration, we store one random message for each stream, replacing any previous sample from earlier iteration
- We collect samples from public streams only

The sample message can be in JSON or binary format. JSON is returned as a plain string and binary as base64-encoded string.