### PR TITLE
feat: add multi-platform docker image support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' }}
           tags: streamr/stream-metrics-index:latest
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,4 @@ jobs:
         with:
           push: true
           tags: streamr/stream-metrics-index:latest
+          platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,10 @@ RUN npm run build
 RUN chmod +x dist/bin/*.js
 RUN rm -rf node_modules
 
-FROM node:18-bullseye-slim
+FROM node:18-bullseye
 USER node
 WORKDIR /usr/src/app
 COPY --chown=node:node --from=build /usr/src/app/ .
-RUN apt-get update && apt-get install -y python3
 RUN npm ci --omit=dev
 
 EXPOSE 4001/tcp

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ FROM node:18-bullseye-slim
 USER node
 WORKDIR /usr/src/app
 COPY --chown=node:node --from=build /usr/src/app/ .
+RUN apt-get update && apt-get install -y python3
 RUN npm ci --omit=dev
 
 EXPOSE 4001/tcp

--- a/README.md
+++ b/README.md
@@ -40,3 +40,7 @@ npm run test
 ## API
 
 The API reference is available at the GraphQL endpoint (see "Docs" in the upper right corner).
+
+## Future improvements
+
+Use node:18-bullseye-slim instead of node:18-bullseye, the image is half the size (compressed). Potential problem: "npm ci" (on arm64 at least) requires node-gyp requires python, so it must be installed first ("half the size" is only without python...).

--- a/README.md
+++ b/README.md
@@ -40,7 +40,3 @@ npm run test
 ## API
 
 The API reference is available at the GraphQL endpoint (see "Docs" in the upper right corner).
-
-## Future improvements
-
-Use node:18-bullseye-slim instead of node:18-bullseye, the image is half the size (compressed). Potential problem: "npm ci" (on arm64 at least) requires node-gyp requires python, so it must be installed first ("half the size" is only without python...).

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "scripts": {
     "build": "tsc -b tsconfig.build.json",
+    "docker:build": "docker build --tag streamr/stream-metrics-index:latest .",
+    "docker:push": "docker buildx build --platform linux/amd64,linux/arm64 --tag streamr/stream-metrics-index:latest --push .",
     "test": "jest --runInBand",
     "eslint": "eslint --cache --cache-location=node_modules/.cache/.eslintcache/ '*/**/*.{js,ts}'"
   },


### PR DESCRIPTION
This commit adds support for multi-platform docker images. It includes changes to the CI workflow file to setup QEMU and Docker Buildx, login to Docker Hub, and build and push the docker image for both amd64 and arm64 platforms.

## Future improvements

Use node:18-bullseye-slim instead of node:18-bullseye, the image is half the size (compressed). Potential problem: "npm ci" (on arm64 at least) requires node-gyp requires python, so it must be installed first ("half the size" is only without python...).