### PR TITLE
chore: Change `moduleResolution`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@tsconfig/node20/tsconfig.json",
   "compilerOptions": {
-      "moduleResolution": "node",
       "noImplicitOverride": true,
       "resolveJsonModule": true,
       "incremental": true,


### PR DESCRIPTION
Removed `moduleResolution: node`. 

That is the deprecated alias to `node10` (https://www.typescriptlang.org/tsconfig/#moduleResolution), and we should use modern `node16`/`nodenext` instead. By removing the definition we use the inherited value of `node16` from `@tsconfig/node20/tsconfig.json`.